### PR TITLE
XR-003: rework scoring scheme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "betting_api"
+version = "0.1.0"
+dependencies = [
+ "actix-rt",
+ "actix-web",
+ "chrono",
+ "dotenvy",
+ "mockall",
+ "rstest",
+ "rusqlite",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,21 +487,6 @@ name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
-
-[[package]]
-name = "em2021_api"
-version = "0.1.0"
-dependencies = [
- "actix-rt",
- "actix-web",
- "chrono",
- "dotenvy",
- "mockall",
- "rstest",
- "rusqlite",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "encoding_rs"

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -144,11 +144,11 @@ mod tests {
         let global = &result.table.global;
         assert_eq!(global[0].name, "ToniKroos");
         assert_eq!(global[0].department, "Langenfeld");
-        assert_eq!(global[0].score_sum, 21);
+        assert_eq!(global[0].score_sum, 20);
         assert_eq!(global[0].position, 1);
         assert_eq!(global[0].sum_win_exact, 1);
         assert_eq!(global[0].sum_score_diff, 1);
-        assert_eq!(global[0].extra_point, 15);
+        assert_eq!(global[0].extra_point, 12);
         assert_eq!(global[0].sum_team, 0);
         assert_eq!(global[0].tips.len(), 0);
 
@@ -156,7 +156,7 @@ mod tests {
         assert_eq!(global[1].department, "Langenfeld");
         assert_eq!(global[1].score_sum, 11);
         assert_eq!(global[1].position, 2);
-        assert_eq!(global[1].extra_point, 7);
+        assert_eq!(global[1].extra_point, 6);
 
         assert_eq!(global[2].name, "RobbieFowler");
         assert_eq!(global[2].department, "London");
@@ -178,10 +178,10 @@ mod tests {
         assert_eq!(result.data.user_id, 2);
         assert_eq!(result.data.name, "ToniKroos");
         assert_eq!(result.data.department, "Langenfeld");
-        assert_eq!(result.data.score_sum, 21);
+        assert_eq!(result.data.score_sum, 20);
         assert_eq!(result.data.position, 1);
         assert_eq!(result.data.sum_win_exact, 1);
-        assert_eq!(result.data.extra_point, 15);
+        assert_eq!(result.data.extra_point, 12);
         assert_eq!(result.data.sum_team, 0);
         assert_eq!(result.data.tips.len(), 2);
 
@@ -189,7 +189,7 @@ mod tests {
         assert_eq!(result.data.tips[0].team1.name, "Poland");
         assert_eq!(result.data.tips[0].team2.name, "France");
 
-        assert_eq!(result.data.tips[1].score, 2);
+        assert_eq!(result.data.tips[1].score, 3);
     }
 
     #[actix_rt::test]
@@ -216,12 +216,12 @@ mod tests {
 
         assert_eq!(result[1].match_id, "2".to_string());
         assert_eq!(result[1].user, "ToniKroos");
-        assert_eq!(result[1].score, 4);
+        assert_eq!(result[1].score, 5);
 
         assert_eq!(result[2].match_id, "2".to_string());
         assert_eq!(result[2].team1.name, "Poland");
         assert_eq!(result[2].team2.name, "France");
-        assert_eq!(result[2].score, 1);
+        assert_eq!(result[2].score, 2);
         assert_eq!(result[2].tip_home, Some(2));
         assert_eq!(result[2].tip_away, Some(2));
         assert_eq!(result[2].score_home, Some(1));

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -41,9 +41,9 @@ struct ScoreConfig;
 
 impl ScoreConfig {
     pub const NO_WIN_TEAM: i32 = 0;
-    pub const WIN_EXACT: i32 = 4;
-    pub const WIN_SCORE_DIFF: i32 = 2;
-    pub const WIN_TEAM: i32 = 1;
+    pub const WIN_EXACT: i32 = 5;
+    pub const WIN_SCORE_DIFF: i32 = 3;
+    pub const WIN_TEAM: i32 = 2;
 }
 
 pub fn get_user_rating(
@@ -55,11 +55,11 @@ pub fn get_user_rating(
     for user in &users {
         let mut extra_point = ScoreConfig::NO_WIN_TEAM;
         if user.winner == "ESP" {
-            extra_point = 15;
+            extra_point = 12;
         }
 
         if user.secret_winner == "ESP" {
-            extra_point = 7;
+            extra_point = 6;
         }
 
         let mut user_rating = UserRating {


### PR DESCRIPTION
## Background

The leaderboard barely separated players by prediction quality: an exact score counted only marginally more than getting the goal difference or just the winner, while the champion bonuses dominated the table. Correct draws with the wrong score were also handled inconsistently between services.

## What this changes

Match points now spread more widely across prediction quality — a precise score, a correct goal difference, and a correct tendency each earn a clearly different amount. A correct draw with the wrong final score counts as a correct tendency, matching the web app. The champion and secret-champion bonuses are rebalanced so they no longer overwhelm the points earned from individual matches.