### PR TITLE
BA-004: panic/DoS hardening

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,17 @@
-use actix_web::{App, HttpServer};
+use actix_web::{web, App, HttpServer};
 
 mod db;
 mod routes;
 mod service;
 
+const MAX_BODY_BYTES: usize = 16 * 1024;
+
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     HttpServer::new(|| {
         App::new()
+            .app_data(web::PayloadConfig::new(MAX_BODY_BYTES))
+            .app_data(web::JsonConfig::default().limit(MAX_BODY_BYTES))
             .service(routes::status)
             .service(routes::rating)
             .service(routes::user_by_id)

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -26,10 +26,20 @@ pub struct UserResponse {
     pub data: UserRating,
 }
 
+fn load_user_ratings() -> Result<Vec<UserRating>, HttpResponse> {
+    let past_games =
+        db::get_past_games().map_err(|_| HttpResponse::InternalServerError().finish())?;
+    let users = db::get_users().map_err(|_| HttpResponse::InternalServerError().finish())?;
+    service::get_user_rating(past_games, users)
+        .map_err(|_| HttpResponse::InternalServerError().finish())
+}
+
 #[get("/rating")]
 pub async fn rating() -> ActixResult<impl Responder> {
-    let mut user_rating_list =
-        service::get_user_rating(db::get_past_games().unwrap(), db::get_users().unwrap()).unwrap();
+    let mut user_rating_list = match load_user_ratings() {
+        Ok(list) => list,
+        Err(resp) => return Ok(resp),
+    };
 
     let cloned_user_rating_list = user_rating_list.clone();
     let mut departments: HashSet<String> = HashSet::new();
@@ -66,8 +76,10 @@ pub async fn rating() -> ActixResult<impl Responder> {
 
 #[get("/user/{user_id}")]
 pub async fn user_by_id(user_id: web::Path<i32>) -> ActixResult<impl Responder> {
-    let mut user_rating_list =
-        service::get_user_rating(db::get_past_games().unwrap(), db::get_users().unwrap()).unwrap();
+    let mut user_rating_list = match load_user_ratings() {
+        Ok(list) => list,
+        Err(resp) => return Ok(resp),
+    };
 
     let user_id = user_id.into_inner();
     calculate_positions(&mut user_rating_list, false);
@@ -89,8 +101,10 @@ pub async fn user_by_id(user_id: web::Path<i32>) -> ActixResult<impl Responder> 
 
 #[get("/game/{game_id}")]
 pub async fn get_past_result_by_game_id(game_id: web::Path<String>) -> ActixResult<impl Responder> {
-    let user_rating_list =
-        service::get_user_rating(db::get_past_games().unwrap(), db::get_users().unwrap()).unwrap();
+    let user_rating_list = match load_user_ratings() {
+        Ok(list) => list,
+        Err(resp) => return Ok(resp),
+    };
 
     let game_id = game_id.into_inner();
 

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,11 +1,21 @@
 use crate::db::{get_tips_by_user, Game, Tip, User};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Team {
+    #[serde(default, deserialize_with = "string_or_default")]
     pub name: String,
+    #[serde(default, deserialize_with = "string_or_default")]
     pub tla: String,
+}
+
+fn string_or_default<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt = Option::<String>::deserialize(deserializer)?;
+    Ok(opt.unwrap_or_default())
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -85,8 +95,8 @@ pub fn get_user_rating(
                 user: user.username.clone(),
                 user_id: user.id,
                 score: 0,
-                team1: serde_json::from_str(&game.home_team).unwrap(),
-                team2: serde_json::from_str(&game.away_team).unwrap(),
+                team1: serde_json::from_str(&game.home_team).unwrap_or_default(),
+                team2: serde_json::from_str(&game.away_team).unwrap_or_default(),
                 tip_home: None,
                 tip_away: None,
                 score_home: Some(game.home_score),
@@ -443,6 +453,64 @@ mod tests {
             "Error: score_home: {}, score_away: {}, tip_home: {}, tip_away: {}",
             score_home, score_away, tip_home, tip_away
         );
+    }
+
+    #[test]
+    fn test_team_deserializes_null_and_missing_fields_without_panic() {
+        let null_fields: Team = serde_json::from_str(r#"{"name":null,"tla":null}"#).unwrap();
+        assert_eq!(null_fields.name, "");
+        assert_eq!(null_fields.tla, "");
+
+        let missing_fields: Team = serde_json::from_str("{}").unwrap();
+        assert_eq!(missing_fields.name, "");
+        assert_eq!(missing_fields.tla, "");
+
+        let partial: Team = serde_json::from_str(r#"{"name":"Germany"}"#).unwrap();
+        assert_eq!(partial.name, "Germany");
+        assert_eq!(partial.tla, "");
+    }
+
+    #[test]
+    fn test_get_user_rating_does_not_panic_on_malformed_team_json() {
+        let games = vec![
+            Game {
+                id: 1,
+                home_team: r#"{"name":null,"tla":null}"#.to_string(),
+                away_team: "not valid json".to_string(),
+                home_score: 1,
+                away_score: 0,
+                date: 1718048296,
+            },
+            Game {
+                id: 2,
+                home_team: "{}".to_string(),
+                away_team: r#"{"name":"France","tla":"FRA"}"#.to_string(),
+                home_score: 2,
+                away_score: 2,
+                date: 1718048297,
+            },
+        ];
+
+        let users = vec![User {
+            id: 999,
+            username: "TestUser".to_string(),
+            department: "test".to_string(),
+            winner: String::new(),
+            secret_winner: String::new(),
+        }];
+
+        std::env::set_var("MODE", "test");
+        let result = get_user_rating(games, users).expect("rating computation must not error");
+
+        assert_eq!(result.len(), 1);
+        let tips = &result[0].tips;
+        assert_eq!(tips.len(), 2);
+        assert_eq!(tips[0].team1.name, "");
+        assert_eq!(tips[0].team1.tla, "");
+        assert_eq!(tips[0].team2.name, "");
+        assert_eq!(tips[0].team2.tla, "");
+        assert_eq!(tips[1].team2.name, "France");
+        assert_eq!(tips[1].team2.tla, "FRA");
     }
 
     #[rstest]


### PR DESCRIPTION
## Background

The read API could be brought down by ordinary data: a team record with a missing or null name from the upstream importer, or a transient database lock on the shared database file, would crash the request handler and return errors for everyone until fixed by hand.

## What this changes

The API now tolerates malformed or incomplete team data without crashing, and database errors return a clean server error instead of taking the endpoint down. Request bodies are also size-limited. The leaderboard and match/user endpoints stay available under conditions that previously caused a denial of service.