### PR TITLE
XR-005: SQLite busy_timeout + WAL (betting-api)

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -44,7 +44,14 @@ pub fn establish_connection() -> SqliteResult<Connection> {
     } else {
         let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
         //fixtures::load_fixtures(&connection); # only when we want to load fixtures for start you local server and you dont have db
-        Connection::open(database_url)?
+        let connection = Connection::open(database_url)?;
+        // Shared DB with frontend + macht-api: wait for the lock instead of
+        // failing with SQLITE_BUSY, and use WAL so readers don't block writers.
+        connection.busy_timeout(std::time::Duration::from_millis(5000))?;
+        connection.query_row("PRAGMA journal_mode = WAL", [], |row| {
+            row.get::<_, String>(0)
+        })?;
+        connection
     };
 
     Ok(conn)


### PR DESCRIPTION
## Background

The read API shares one SQLite database with the importer and the web app. Without a busy timeout, a read could fail immediately while another service was writing.

## What this changes

The read API now waits briefly for the database lock and uses write-ahead logging, so reads no longer fail when the importer or web app is writing at the same time.