### PR TITLE
FE-050: configurable bind address (BIND_ADDR)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,17 @@
 use actix_web::{web, App, HttpServer};
+use std::env;
 
 mod db;
 mod routes;
 mod service;
 
 const MAX_BODY_BYTES: usize = 16 * 1024;
+const DEFAULT_BIND_ADDR: &str = "127.0.0.1:8080";
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+    let bind_addr = env::var("BIND_ADDR").unwrap_or_else(|_| DEFAULT_BIND_ADDR.to_string());
+
     HttpServer::new(|| {
         App::new()
             .app_data(web::PayloadConfig::new(MAX_BODY_BYTES))
@@ -17,7 +21,7 @@ async fn main() -> std::io::Result<()> {
             .service(routes::user_by_id)
             .service(routes::get_past_result_by_game_id)
     })
-    .bind("127.0.0.1:8080")?
+    .bind(bind_addr)?
     .run()
     .await
 }


### PR DESCRIPTION
## Background
The read API was hard-coded to one address, so a second instance could not run on a different port. The end-to-end test stand needs to start its own read-API instance on a dedicated port alongside a developer's running stack, without touching the shared database.

## What this changes
The read API now takes its bind address from the environment, falling back to the previous default when unset. Existing deployments are unaffected.