### PR TITLE
XR-008: tournament-winner bonus via env

### DIFF
--- a/src/routes.rs
+++ b/src/routes.rs
@@ -30,7 +30,8 @@ fn load_user_ratings() -> Result<Vec<UserRating>, HttpResponse> {
     let past_games =
         db::get_past_games().map_err(|_| HttpResponse::InternalServerError().finish())?;
     let users = db::get_users().map_err(|_| HttpResponse::InternalServerError().finish())?;
-    service::get_user_rating(past_games, users)
+    let tournament_winner = std::env::var("TOURNAMENT_WINNER").unwrap_or_default();
+    service::get_user_rating(past_games, users, &tournament_winner)
         .map_err(|_| HttpResponse::InternalServerError().finish())
 }
 
@@ -136,6 +137,7 @@ mod tests {
 
     #[actix_web::test]
     async fn test_get_user_rating() {
+        env::set_var("TOURNAMENT_WINNER", "ESP");
         let resp = get_response_by_url("/rating").await;
 
         assert!(resp.status().is_success());
@@ -183,6 +185,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_user_by_id_returns_user_when_exists() {
+        env::set_var("TOURNAMENT_WINNER", "ESP");
         let resp = get_response_by_url("/user/2").await;
 
         assert!(resp.status().is_success());

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -54,22 +54,29 @@ impl ScoreConfig {
     pub const WIN_EXACT: i32 = 5;
     pub const WIN_SCORE_DIFF: i32 = 3;
     pub const WIN_TEAM: i32 = 2;
+    pub const WINNER_BONUS: i32 = 12;
+    pub const SECRET_WINNER_BONUS: i32 = 6;
 }
 
 pub fn get_user_rating(
     games: Vec<Game>,
     users: Vec<User>,
+    tournament_winner: &str,
 ) -> Result<Vec<UserRating>, Box<dyn std::error::Error>> {
     let mut user_rating_list = Vec::new();
+    let tournament_winner = tournament_winner.trim();
 
     for user in &users {
+        // The tournament champion is configured via env (TOURNAMENT_WINNER).
+        // Until it is set there is no winner yet, so nobody earns the bonus.
         let mut extra_point = ScoreConfig::NO_WIN_TEAM;
-        if user.winner == "ESP" {
-            extra_point = 12;
-        }
-
-        if user.secret_winner == "ESP" {
-            extra_point = 6;
+        if !tournament_winner.is_empty() {
+            if user.winner == tournament_winner {
+                extra_point = ScoreConfig::WINNER_BONUS;
+            }
+            if user.secret_winner == tournament_winner {
+                extra_point = ScoreConfig::SECRET_WINNER_BONUS;
+            }
         }
 
         let mut user_rating = UserRating {
@@ -500,7 +507,7 @@ mod tests {
         }];
 
         std::env::set_var("MODE", "test");
-        let result = get_user_rating(games, users).expect("rating computation must not error");
+        let result = get_user_rating(games, users, "").expect("rating computation must not error");
 
         assert_eq!(result.len(), 1);
         let tips = &result[0].tips;


### PR DESCRIPTION
## Background
The tournament-winner bonus was hard-coded to a single team, so a bonus was always granted even though no champion has been decided yet. The winning team should be configurable, and with no winner set there should be no bonus.

## What this changes
The champion is now read from the TOURNAMENT_WINNER environment variable. While it is unset there is no winner, so nobody receives the winner/secret-winner bonus. Setting it later (and restarting) awards the bonus to users whose picks match.