### PR TITLE
BA-007: rating endpoint performance (serialized hot path)

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,6 +1,5 @@
 mod fixtures;
 
-use dotenvy::dotenv;
 use rusqlite::{Connection, Result as SqliteResult};
 use serde::Serialize;
 use std::env;
@@ -33,9 +32,10 @@ pub struct Game {
     pub date: i64,
 }
 
+// Opens a single connection. Callers reuse one connection per request rather
+// than opening one per query. Env (.env) is loaded ONCE in main(), never here,
+// so this stays free of file I/O and the global env lock on the hot path.
 pub fn establish_connection() -> SqliteResult<Connection> {
-    dotenv().ok();
-
     let mode = env::var("MODE").unwrap_or_else(|_| String::from("production"));
     let conn = if mode == "test" {
         let connection = Connection::open_in_memory()?;
@@ -43,7 +43,6 @@ pub fn establish_connection() -> SqliteResult<Connection> {
         connection
     } else {
         let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
-        //fixtures::load_fixtures(&connection); # only when we want to load fixtures for start you local server and you dont have db
         let connection = Connection::open(database_url)?;
         // Shared DB with frontend + macht-api: wait for the lock instead of
         // failing with SQLITE_BUSY, and use WAL so readers don't block writers.
@@ -57,9 +56,7 @@ pub fn establish_connection() -> SqliteResult<Connection> {
     Ok(conn)
 }
 
-pub fn get_users() -> SqliteResult<Vec<User>> {
-    let conn = establish_connection()?;
-
+pub fn get_users(conn: &Connection) -> SqliteResult<Vec<User>> {
     let mut stmt =
         conn.prepare("SELECT id, username, department, winner, secretWinner FROM user")?;
 
@@ -81,17 +78,17 @@ pub fn get_users() -> SqliteResult<Vec<User>> {
     Ok(user_list)
 }
 
-pub fn get_tips_by_user(user_id: i32) -> SqliteResult<Vec<Tip>> {
-    let conn = establish_connection()?;
-
+// Every still-countable tip (placed before kickoff, BA-003) for all users in a
+// single query, so the rating computation avoids an N+1 query per user.
+pub fn get_all_tips(conn: &Connection) -> SqliteResult<Vec<Tip>> {
     let mut stmt = conn.prepare(
         "SELECT t.id, t.user_id, t.match_id, t.score_home, t.score_away \
          FROM tip t JOIN match m ON m.id = t.match_id \
-         WHERE t.user_id = ?1 AND t.date < m.utcDate \
+         WHERE t.date < m.utcDate \
          ORDER BY t.id",
     )?;
 
-    let tips_iter = stmt.query_map([user_id], |row| {
+    let tips_iter = stmt.query_map([], |row| {
         Ok(Tip {
             id: row.get(0)?,
             user_id: row.get(1)?,
@@ -109,9 +106,7 @@ pub fn get_tips_by_user(user_id: i32) -> SqliteResult<Vec<Tip>> {
     Ok(tips_list)
 }
 
-pub fn get_past_games() -> SqliteResult<Vec<Game>> {
-    let conn = establish_connection()?;
-
+pub fn get_past_games(conn: &Connection) -> SqliteResult<Vec<Game>> {
     let mut stmt = conn.prepare("SELECT id, homeTeam, awayTeam, homeScore, awayScore, utcDate FROM match WHERE homeScore >= 0 AND awayScore >= 0")?;
 
     let game_iter = match stmt.query_map([], |row| {
@@ -144,7 +139,8 @@ mod tests {
     #[test]
     fn test_get_users() {
         env::set_var("MODE", "test");
-        let users = get_users().unwrap();
+        let conn = establish_connection().unwrap();
+        let users = get_users(&conn).unwrap();
         assert_eq!(users.len(), 7);
 
         assert_eq!(users[0].username, "JohnDoe");
@@ -161,9 +157,14 @@ mod tests {
     }
 
     #[test]
-    fn test_get_tips_by_user() {
+    fn test_get_all_tips_for_user() {
         env::set_var("MODE", "test");
-        let tips = get_tips_by_user(1).unwrap();
+        let conn = establish_connection().unwrap();
+        let tips: Vec<Tip> = get_all_tips(&conn)
+            .unwrap()
+            .into_iter()
+            .filter(|t| t.user_id == 1)
+            .collect();
         assert_eq!(tips.len(), 2);
 
         assert_eq!(tips[0].id, 1);
@@ -180,9 +181,14 @@ mod tests {
     }
 
     #[test]
-    fn test_get_tips_by_user_excludes_post_kickoff_tips() {
+    fn test_get_all_tips_excludes_post_kickoff_tips() {
         env::set_var("MODE", "test");
-        let tips = get_tips_by_user(6).unwrap();
+        let conn = establish_connection().unwrap();
+        let tips: Vec<Tip> = get_all_tips(&conn)
+            .unwrap()
+            .into_iter()
+            .filter(|t| t.user_id == 6)
+            .collect();
         assert!(
             tips.iter().any(|t| t.match_id == 1),
             "pre-kickoff tip on match 1 must remain scored"
@@ -196,7 +202,8 @@ mod tests {
     #[test]
     fn test_get_past_games() {
         env::set_var("MODE", "test");
-        let games = get_past_games().unwrap();
+        let conn = establish_connection().unwrap();
+        let games = get_past_games(&conn).unwrap();
         assert_eq!(games.len(), 2);
 
         assert_eq!(games[0].id, 1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,10 @@ const DEFAULT_BIND_ADDR: &str = "127.0.0.1:8080";
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+    // Load .env ONCE at startup — never per DB connection (that hammered the
+    // global env lock + file I/O and serialized the hot path under load).
+    dotenvy::dotenv().ok();
+
     let bind_addr = env::var("BIND_ADDR").unwrap_or_else(|_| DEFAULT_BIND_ADDR.to_string());
 
     HttpServer::new(|| {

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -27,11 +27,15 @@ pub struct UserResponse {
 }
 
 fn load_user_ratings() -> Result<Vec<UserRating>, HttpResponse> {
+    // One connection per request, reused for every query below (instead of one
+    // connection per query, which serialized the hot path under load).
+    let conn =
+        db::establish_connection().map_err(|_| HttpResponse::InternalServerError().finish())?;
     let past_games =
-        db::get_past_games().map_err(|_| HttpResponse::InternalServerError().finish())?;
-    let users = db::get_users().map_err(|_| HttpResponse::InternalServerError().finish())?;
+        db::get_past_games(&conn).map_err(|_| HttpResponse::InternalServerError().finish())?;
+    let users = db::get_users(&conn).map_err(|_| HttpResponse::InternalServerError().finish())?;
     let tournament_winner = std::env::var("TOURNAMENT_WINNER").unwrap_or_default();
-    service::get_user_rating(past_games, users, &tournament_winner)
+    service::get_user_rating(past_games, users, &conn, &tournament_winner)
         .map_err(|_| HttpResponse::InternalServerError().finish())
 }
 

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,4 +1,5 @@
-use crate::db::{get_tips_by_user, Game, Tip, User};
+use crate::db::{get_all_tips, Game, Tip, User};
+use rusqlite::Connection;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 
@@ -61,10 +62,22 @@ impl ScoreConfig {
 pub fn get_user_rating(
     games: Vec<Game>,
     users: Vec<User>,
+    conn: &Connection,
     tournament_winner: &str,
 ) -> Result<Vec<UserRating>, Box<dyn std::error::Error>> {
     let mut user_rating_list = Vec::new();
     let tournament_winner = tournament_winner.trim();
+
+    // One query for every countable tip, grouped by user — avoids an N+1 query
+    // (one tips query per user) on the hot /rating path.
+    let mut tips_by_user: HashMap<i32, HashMap<i32, Tip>> = HashMap::new();
+    for tip in get_all_tips(conn)? {
+        tips_by_user
+            .entry(tip.user_id)
+            .or_default()
+            .insert(tip.match_id, tip);
+    }
+    let no_tips: HashMap<i32, Tip> = HashMap::new();
 
     for user in &users {
         // The tournament champion is configured via env (TOURNAMENT_WINNER).
@@ -91,10 +104,7 @@ pub fn get_user_rating(
             extra_point,
             tips: Vec::new(),
         };
-        let tips_by_user: HashMap<i32, Tip> = get_tips_by_user(user.id)?
-            .into_iter()
-            .map(|tip| (tip.match_id, tip))
-            .collect();
+        let user_tips = tips_by_user.get(&user.id).unwrap_or(&no_tips);
 
         for game in &games {
             let mut match_info = MatchInfo {
@@ -111,7 +121,7 @@ pub fn get_user_rating(
                 date: game.date,
             };
 
-            if let Some(tip) = tips_by_user.get(&game.id) {
+            if let Some(tip) = user_tips.get(&game.id) {
                 match_info.tip_home = Some(tip.score_home);
                 match_info.tip_away = Some(tip.score_away);
 
@@ -507,7 +517,9 @@ mod tests {
         }];
 
         std::env::set_var("MODE", "test");
-        let result = get_user_rating(games, users, "").expect("rating computation must not error");
+        let conn = crate::db::establish_connection().unwrap();
+        let result =
+            get_user_rating(games, users, &conn, "").expect("rating computation must not error");
 
         assert_eq!(result.len(), 1);
         let tips = &result[0].tips;


### PR DESCRIPTION
## Background
Under load the read API plateaued at ~280 req/s on /rating regardless of concurrency, with latency rising linearly — the classic signature of a serialized hot path rather than a CPU limit. The cause was per-request overhead, not the live computation: the .env file was re-read and the process-global env lock taken on every DB connection, a fresh connection was opened for every query, and the rating computation issued one tips query per user (N+1).

## What this changes
The environment is now loaded once at startup instead of on every connection, each request reuses a single database connection instead of opening one per query, and all countable tips are fetched in a single query and grouped in memory instead of one query per user. The leaderboard is still computed fully live (no caching); only the wasteful per-request work is removed.